### PR TITLE
Made the executables work when this package is used as a depenency.

### DIFF
--- a/bin/ciconia
+++ b/bin/ciconia
@@ -7,7 +7,20 @@ if (PHP_SAPI !== 'cli') {
     echo 'Ciconia command should be run on the CLI environment.' . PHP_EOL;
 }
 
-require __DIR__ . '/../vendor/autoload.php';
+$paths = [
+    // Top-level package.
+    __DIR__ . '/../vendor/autoload.php',
+
+    // Included as a dependency.
+    __DIR__ . '/../../../autoload.php',
+];
+
+foreach($paths as $path) {
+    if (file_exists($path)) {
+        require $path;
+        break;
+    }
+}
 
 $app = new Application('Ciconia', \Ciconia\Ciconia::VERSION);
 $app->run();

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,20 @@ if (PHP_SAPI !== 'cli') {
     die('Compile command must be run on the CLI environment.');
 }
 
-require __DIR__ . '/../vendor/autoload.php';
+$paths = [
+    // Top-level package.
+    __DIR__ . '/../vendor/autoload.php',
+
+    // Included as a dependency.
+    __DIR__ . '/../../../autoload.php',
+];
+
+foreach($paths as $path) {
+    if (file_exists($path)) {
+        require $path;
+        break;
+    }
+}
 
 $app = new Application('Ciconia Compiler', \Ciconia\Ciconia::VERSION);
 $app->add(new CompileCommand());


### PR DESCRIPTION
When this package is used as a dependency, the executables can't run, because 'autoload.php' is in a different relative path.

This patch fixes this for both binaries, and also turns on the executable bit.
