### PR TITLE
$extensions should be protected

### DIFF
--- a/src/Ciconia/Ciconia.php
+++ b/src/Ciconia/Ciconia.php
@@ -34,7 +34,7 @@ class Ciconia
     /**
      * @var Collection|ExtensionInterface[]
      */
-    private $extensions;
+    protected $extensions;
 
     /**
      * @param RendererInterface $renderer


### PR DESCRIPTION
When you inherits from Ciconia class you can not access $extensions because it's private. Nightmare!
