### PR TITLE
Fix some issues with the list extension

### DIFF
--- a/src/Ciconia/Extension/Core/ListExtension.php
+++ b/src/Ciconia/Extension/Core/ListExtension.php
@@ -63,24 +63,23 @@ class ListExtension implements ExtensionInterface, RendererAwareInterface, Emitt
         $lessThanTab = $options['tabWidth'] - 1;
 
         $wholeList = '
-            #(                                 # $1 = whole list
-              (                               # $2
-                [ ]{0,' . $lessThanTab . '}
-                (' . $this->getPattern() . ') # $3 = first list item marker
-                [ \t]+
-              )
-              (?s:.+?)
-              (?:                             # $4
-                  \z
-                |
-                  \n{2,}
-                  (?=\S)
-                  (?!                         # Negative lookahead for another list item marker
-                    [ \t]*
-                    ' . $this->getPattern() . '[ \t]+
-                  )
-              )
-            #)
+            (                               # $1
+              [ ]{0,' . $lessThanTab . '}
+              # $2 = first list item marker; $3 captures for the conditional subpattern below
+              ((' . $this->ul . ')|' . $this->ol . ')
+              [ \t]+
+            )
+            (?s:.+?)
+            (?:
+                \z
+              |
+                \n{2,}
+                (?=\S)
+                (?!                         # Negative lookahead for another list item marker
+                  [ \t]*
+                  (?(3)\3|' . $this->ol . ')[ \t]+ # Only match the same kind of marker
+                )
+            )
         ';
 
         /** @noinspection PhpUnusedParameterInspection */


### PR DESCRIPTION
This pull request improves the rendering of subsequent lists. It solves some issues highlighted in #30.

Rendering fixes
- Unordered and ordered lists are now always separated.

```
- item1
- item2
- item3

1. item1
2. item2
3. item3
```
- An unordered list must retain the same list marker throughout the list, otherwise it will be split

```
- item1
- item2
- item3

* item1
* item2
* item3
```

Note: #30 mentions an issue when parsing this code:

```
- item1
- item2
- item3

test
1. item1
2. item2
3. item3

* item1
* item2
* item3
```

This PR does not change the rendering of this code, since it is not wrong. To make this example work as expected use the following markdown code:

```
- item1
- item2
- item3

test

1. item1
2. item2
3. item3

* item1
* item2
* item3
```
