### PR TITLE
Adding language class to code tags as recommended by HTML5 specs

### DIFF
--- a/src/Ciconia/Extension/Gfm/FencedCodeBlockExtension.php
+++ b/src/Ciconia/Extension/Gfm/FencedCodeBlockExtension.php
@@ -56,7 +56,7 @@ class FencedCodeBlockExtension implements ExtensionInterface, RendererAwareInter
                 \1                    # matched #1
             )
         }smx', function (Text $w, Text $fence, Text $lang, Text $code) use ($options) {
-            $rendererOptions = [];
+            $preRendererOptions = $codeRendererOptions = [];
 
             if (!$lang->isEmpty()) {
                 if ($options['pygments'] && class_exists('KzykHys\Pygments\Pygments')) {
@@ -66,9 +66,14 @@ class FencedCodeBlockExtension implements ExtensionInterface, RendererAwareInter
                     return "\n\n" . $html . "\n\n";
                 }
 
-                $rendererOptions = [
+                $preRendererOptions = [
                     'attr' => [
                         'class' => 'prettyprint lang-' . $lang->lower()
+                    ]
+                ];
+                $codeRendererOptions = [
+                    'attr' => [
+                        'class' => 'language-' . $lang->lower()
                     ]
                 ];
             }
@@ -78,7 +83,7 @@ class FencedCodeBlockExtension implements ExtensionInterface, RendererAwareInter
             $code->replace('/\A\n+/', '');
             $code->replace('/\s+\z/', '');
 
-            return "\n\n" . $this->getRenderer()->renderCodeBlock($code, $rendererOptions) . "\n\n";
+            return "\n\n" . $this->getRenderer()->renderCodeBlock($code, $preRendererOptions, $codeRendererOptions) . "\n\n";
         });
     }
 

--- a/src/Ciconia/Renderer/HtmlRenderer.php
+++ b/src/Ciconia/Renderer/HtmlRenderer.php
@@ -56,18 +56,21 @@ class HtmlRenderer implements RendererInterface, EmitterAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function renderCodeBlock($content, array $options = array())
+    public function renderCodeBlock($content, array $preOptions = array(), array $codeOptions = array())
     {
         if (!$content instanceof Text) {
             $content = new Text($content);
         }
 
-        $options = $this->createResolver()->resolve($options);
+        $resolver = $this->createResolver();
+        $preOptions = $resolver->resolve($preOptions);
+        $codeOptions = $resolver->resolve($preOptions);
 
         $tag = Tag::create('pre')
-            ->setAttributes($options['attr'])
+            ->setAttributes($preOptions['attr'])
             ->setText(
                 Tag::create('code')
+                    ->setAttributes($codeOptions['attr'])
                     ->setText($content->append("\n"))
                     ->render()
             );

--- a/src/Ciconia/Renderer/HtmlRenderer.php
+++ b/src/Ciconia/Renderer/HtmlRenderer.php
@@ -64,7 +64,7 @@ class HtmlRenderer implements RendererInterface, EmitterAwareInterface
 
         $resolver = $this->createResolver();
         $preOptions = $resolver->resolve($preOptions);
-        $codeOptions = $resolver->resolve($preOptions);
+        $codeOptions = $resolver->resolve($codeOptions);
 
         $tag = Tag::create('pre')
             ->setAttributes($preOptions['attr'])

--- a/src/Ciconia/Renderer/RendererInterface.php
+++ b/src/Ciconia/Renderer/RendererInterface.php
@@ -37,11 +37,12 @@ interface RendererInterface
      * @api
      *
      * @param string|Text $content
-     * @param array       $options
+     * @param array       $preOptions
+     * @param array       $codeOptions
      *
      * @return string
      */
-    public function renderCodeBlock($content, array $options = array());
+    public function renderCodeBlock($content, array $preOptions = array(), array $codeOptions = array());
 
     /**
      * @api

--- a/test/Ciconia/Resources/gfm/fenced-code-block-syntax.out
+++ b/test/Ciconia/Resources/gfm/fenced-code-block-syntax.out
@@ -2,7 +2,7 @@
 code block
 </code></pre>
 
-<pre class="prettyprint lang-php"><code>&lt;?php
+<pre class="prettyprint lang-php"><code class="language-php">&lt;?php
 
 class Test
 {

--- a/test/Ciconia/Resources/gfm/link-in-codeblock.out
+++ b/test/Ciconia/Resources/gfm/link-in-codeblock.out
@@ -1,2 +1,2 @@
-<pre class="prettyprint lang-php"><code>$validator-&gt;validate('http://www.example.com/');
+<pre class="prettyprint lang-php"><code class="language-php">$validator-&gt;validate('http://www.example.com/');
 </code></pre>


### PR DESCRIPTION
Specifications by W3C recommend to add a class to the code tag to indicate the language being used. Several code highlighting libraries, such as Prism or highlight.js, use this declaration to determine which language is being used.
Specifications can be found here: http://www.w3.org/TR/html5/text-level-semantics.html#the-code-element
